### PR TITLE
Apply New REST API for NHN Cloud VPC and Subnet

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -31,7 +31,7 @@ const (
 
 func init() {
 	// cblog is a global variable.
-	cblogger = cblog.GetLogger("OpenStack Client")
+	cblogger = cblog.GetLogger("NHN Cloud Client")
 }
 
 /*

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -11,6 +11,7 @@
 package subnets
 
 import (
+	"fmt"
 	"github.com/cloud-barista/nhncloud-sdk-go"
 	"github.com/cloud-barista/nhncloud-sdk-go/pagination"
 )
@@ -30,7 +31,7 @@ type ListOpts struct {									// Modified
 	ID              string `q:"id"`
 	Name            string `q:"name"`
 	EnableDHCP      *bool  `q:"enable_dhcp"`
-	NetworkID       string `q:"network_id"`
+	VPCID       	string `q:"vpc_id"`
 	CIDR            string `q:"cidr"`
 	Shared          bool   `q:"shared"`	// Whether the subnet is shared. (Added )
 	SortDir         string `q:"sort_dir"`
@@ -60,6 +61,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 		}
 		url += query
 	}
+
+	fmt.Printf("\n### Call URL : %s\n\n", url)
+
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return SubnetPage{pagination.LinkedPageBase{PageResult: r}}
 	})
@@ -67,6 +71,8 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 
 // Get retrieves a specific subnet based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	fmt.Printf("\n### Call URL : %s\n\n", getURL(c, id))
+	
 	resp, err := c.Get(getURL(c, id), &r.Body, nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
@@ -99,10 +105,6 @@ type CreateOpts struct {
 	// The UUID of the project who owns the Subnet. Only administrative users
 	// can specify a project UUID other than their own.
 	ProjectID string `json:"project_id,omitempty"`
-
-	// AllocationPools are IP Address pools that will be available for DHCP.
-	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`
-
 	// GatewayIP sets gateway information for the subnet. Setting to nil will
 	// cause a default gateway to automatically be created. Setting to an empty
 	// string will cause the subnet to be created with no gateway. Setting to
@@ -117,9 +119,6 @@ type CreateOpts struct {
 
 	// DNSNameservers are the nameservers to be set via DHCP.
 	DNSNameservers []string `json:"dns_nameservers,omitempty"`
-
-	// HostRoutes are any static host routes to be set via DHCP.
-	HostRoutes []HostRoute `json:"host_routes,omitempty"`
 
 	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
 	IPv6AddressMode string `json:"ipv6_address_mode,omitempty"`
@@ -178,9 +177,6 @@ type UpdateOpts struct {
 	// Description of the subnet.
 	Description *string `json:"description,omitempty"`
 
-	// AllocationPools are IP Address pools that will be available for DHCP.
-	AllocationPools []AllocationPool `json:"allocation_pools,omitempty"`
-
 	// GatewayIP sets gateway information for the subnet. Setting to nil will
 	// cause a default gateway to automatically be created. Setting to an empty
 	// string will cause the subnet to be created with no gateway. Setting to
@@ -189,9 +185,6 @@ type UpdateOpts struct {
 
 	// DNSNameservers are the nameservers to be set via DHCP.
 	DNSNameservers *[]string `json:"dns_nameservers,omitempty"`
-
-	// HostRoutes are any static host routes to be set via DHCP.
-	HostRoutes *[]HostRoute `json:"host_routes,omitempty"`
 
 	// EnableDHCP will either enable to disable the DHCP service.
 	EnableDHCP *bool `json:"enable_dhcp,omitempty"`

--- a/openstack/networking/v2/subnets/results.go
+++ b/openstack/networking/v2/subnets/results.go
@@ -6,7 +6,7 @@
 //
 // This is a Cloud Driver Example for PoC Test.
 //
-// Modified by ETRI, 2022.07
+// Modified by ETRI, 2024.02
 
 package subnets
 
@@ -22,7 +22,7 @@ type commonResult struct {
 // Extract is a function that accepts a result and extracts a subnet resource.
 func (r commonResult) Extract() (*Subnet, error) {
 	var s struct {
-		Subnet *Subnet `json:"subnet"`
+		Subnet *Subnet `json:"vpcsubnet"` // Modified
 	}
 	err := r.ExtractInto(&s)
 	return s.Subnet, err
@@ -52,67 +52,46 @@ type DeleteResult struct {
 	gophercloud.ErrResult
 }
 
-// AllocationPool represents a sub-range of cidr available for dynamic
-// allocation to ports, e.g. {Start: "10.0.0.2", End: "10.0.0.254"}
-type AllocationPool struct {
-	Start string `json:"start"`
-	End   string `json:"end"`
+type Subnet struct {
+    RouterExternal    bool         `json:"router:external"`
+    Name              string       `json:"name"`
+    TenantID          string       `json:"tenant_id"`
+    State             string       `json:"state"`
+    ID                string       `json:"id"`
+    RoutingTable      RoutingTable `json:"routingtable"`
+    CreateTime        string       `json:"create_time"`
+    AvailableIPCount  int          `json:"available_ip_count"`
+    VPC               VPC          `json:"vpc"`
+    VPCID             string       `json:"vpc_id"`
+    Routes            []Route      `json:"routes"`
+    Shared            bool         `json:"shared"`
+    CIDR              string       `json:"cidr"`
+    Gateway           string       `json:"gateway"`
 }
 
-// HostRoute represents a route that should be used by devices with IPs from
-// a subnet (not including local subnet route).
-type HostRoute struct {
-	DestinationCIDR string `json:"destination"`
-	NextHop         string `json:"nexthop"`
+type RoutingTable struct {
+    GatewayID    string `json:"gateway_id"`
+    DefaultTable bool   `json:"default_table"`
+    Explicit     bool   `json:"explicit"`
+    ID           string `json:"id"`
+    Name         string `json:"name"`
 }
 
-// Subnet represents a subnet. See package documentation for a top-level
-// description of what this is.
-type Subnet struct {											// Modified 
-	// Human-readable name for the subnet. Might not be unique.
-	Name string `json:"name"`
+type VPC struct {
+    Shared bool   `json:"shared"`
+    State  string `json:"state"`
+    ID     string `json:"id"`
+    CIDRv4 string `json:"cidrv4"`
+    Name   string `json:"name"`
+}
 
-	// Specifies whether DHCP is enabled for this subnet or not.
-	EnableDHCP bool `json:"enable_dhcp"`
-
-	// UUID of the parent network.
-	NetworkID string `json:"network_id"`
-
-	// TenantID is the project owner of the subnet.
-	TenantID string `json:"tenant_id"`
-
-	// DNS name servers used by hosts in this subnet.
-	DNSNameservers []string `json:"dns_nameservers"`
-
-	// Default gateway used by devices in this subnet.
-	GatewayIP string `json:"gateway_ip"`
-
-	// The IPv6 router advertisement specifies whether the networking service
-	// should transmit ICMPv6 packets.
-	IPv6RAMode string `json:"ipv6_ra_mode"`
-
-	// Sub-ranges of CIDR available for dynamic allocation to ports.
-	// See AllocationPool.
-	AllocationPools []AllocationPool `json:"allocation_pools"`
-
-	// Routes that should be used by devices with IPs from this subnet
-	// (not including local subnet route).
-	HostRoutes []HostRoute `json:"host_routes"`
-
-	// IP version, either `4' or `6'.
-	IPVersion int `json:"ip_version"`
-
-	// The IPv6 address modes specifies mechanisms for assigning IPv6 IP addresses.
-	IPv6AddressMode string `json:"ipv6_address_mode"`
-
-	// CIDR representing IP range for this subnet, based on IP version.
-	CIDR string `json:"cidr"`
-
-	// UUID representing the subnet.
-	ID string `json:"id"`
-
-	// SubnetPoolID is the id of the subnet pool associated with the subnet.
-	SubnetPoolID string `json:"subnetpool_id"`
+type Route struct {
+    SubnetID string `json:"subnet_id"`
+    TenantID string `json:"tenant_id"`
+    Mask     int    `json:"mask"`
+    Gateway  string `json:"gateway"`
+    CIDR     string `json:"cidr"`
+    ID       string `json:"id"`
 }
 
 // SubnetPage is the page returned by a pager when traversing over a collection
@@ -126,7 +105,7 @@ type SubnetPage struct {
 // to do this, it needs to construct the next page's URL.
 func (r SubnetPage) NextPageURL() (string, error) {
 	var s struct {
-		Links []gophercloud.Link `json:"subnets_links"`
+		Links []gophercloud.Link `json:"vpcsubnets_links"`
 	}
 	err := r.ExtractInto(&s)
 	if err != nil {
@@ -146,7 +125,7 @@ func (r SubnetPage) IsEmpty() (bool, error) {
 // a generic collection is mapped into a relevant slice.
 func ExtractSubnets(r pagination.Page) ([]Subnet, error) {
 	var s struct {
-		Subnets []Subnet `json:"subnets"`
+		Subnets []Subnet `json:"vpcsubnets"` // Modified
 	}
 	err := (r.(SubnetPage)).ExtractInto(&s)
 	return s.Subnets, err

--- a/openstack/networking/v2/subnets/urls.go
+++ b/openstack/networking/v2/subnets/urls.go
@@ -1,13 +1,23 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// Modified by ETRI, 2024.02
+
 package subnets
 
 import "github.com/cloud-barista/nhncloud-sdk-go"
 
 func resourceURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("subnets", id)
+	return c.ServiceURL("vpcsubnets", id) // Modified
 }
 
 func rootURL(c *gophercloud.ServiceClient) string {
-	return c.ServiceURL("subnets")
+	return c.ServiceURL("vpcsubnets")	// Modified
 }
 
 func listURL(c *gophercloud.ServiceClient) string {

--- a/openstack/networking/v2/vpcs/requests.go
+++ b/openstack/networking/v2/vpcs/requests.go
@@ -1,0 +1,164 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// Created by ETRI, 2024.02
+
+package vpcs
+
+import (
+	"fmt"
+	"github.com/cloud-barista/nhncloud-sdk-go"
+	"github.com/cloud-barista/nhncloud-sdk-go/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToVPCListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the network attributes you want to see returned. SortKey allows you to sort
+// by a particular network attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Status       string `q:"status"`
+	Name         string `q:"name"`
+	Description  string `q:"description"`
+	AdminStateUp *bool  `q:"admin_state_up"`
+	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
+	Shared       *bool  `q:"shared"`
+	ID           string `q:"id"`
+	Marker       string `q:"marker"`
+	Limit        int    `q:"limit"`
+	SortKey      string `q:"sort_key"`
+	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
+}
+
+// ToVPCListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVPCListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// networks. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToVPCListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	fmt.Printf("\n### Call URL : %s\n\n", url)
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return VPCPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific network based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	fmt.Printf("\n### Call URL : %s\n\n", getURL(c, id))
+
+	resp, err := c.Get(getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVPCCreateMap() (map[string]interface{}, error)
+}
+
+type NewVPC struct {
+	Name   				string  	`json:"name,omitempty"`
+	CidrV4				string  	`json:"cidrv4,omitempty"`
+	TenantID			string 		`json:"tenant_id,omitempty"`
+	ExternalNetworkID 	string		`json:"external_network_id,omitempty"`
+}
+
+// CreateOpts represents options used to create a network.
+type CreateOpts struct {
+	VPC NewVPC `json:"vpc,omitempty"`
+}
+
+// ToVPCCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToVPCCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "network")
+}
+
+// Create accepts a CreateOpts struct and creates a new network using the values
+// provided. This operation does not actually require a request body, i.e. the
+// CreateOpts struct argument can be empty.
+//
+// The tenant ID that is contained in the URI is the tenant that creates the
+// network. An admin user, however, has the option of specifying another tenant
+// ID in the CreateOpts struct.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVPCCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(createURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVPCUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a network.
+type UpdateOpts struct {
+	AdminStateUp *bool   `json:"admin_state_up,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	Shared       *bool   `json:"shared,omitempty"`
+}
+
+// ToVPCUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToVPCUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "network")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing network using the
+// values provided. For more information, see the Create function.
+func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVPCUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(updateURL(c, networkID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete accepts a unique ID and deletes the network associated with it.
+func Delete(c *gophercloud.ServiceClient, networkID string) (r DeleteResult) {
+	resp, err := c.Delete(deleteURL(c, networkID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/networking/v2/vpcs/results.go
+++ b/openstack/networking/v2/vpcs/results.go
@@ -1,0 +1,170 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// Created by ETRI, 2024.02
+
+package vpcs
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/cloud-barista/nhncloud-sdk-go"
+	"github.com/cloud-barista/nhncloud-sdk-go/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a network resource.
+func (r commonResult) Extract() (*VPC, error) {
+	var s VPC
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "vpc")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a VPC.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a VPC.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a VPC.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+type RoutingTable struct {
+    GatewayID    	string    `json:"gateway_id"`
+    Subnets      	[]Subnet  `json:"subnets"`
+    Name         	string    `json:"name"`
+    VPCs         	[]VPC     `json:"vpcs"`
+    TenantID     	string    `json:"tenant_id"`
+    Distributed  	bool      `json:"distributed"`
+    State        	string    `json:"state"`
+    DefaultTable 	bool      `json:"default_table"`
+    CreateTime   	time.Time `json:"create_time"`
+    Routes       	[]Route   `json:"routes"`
+    ID           	string    `json:"id"`
+}
+
+type Route struct {
+	SubnetID 		string `json:"subnet_id"`
+	TenantID 		string `json:"tenant_id"`
+	Mask     		int    `json:"mask"`
+	Gateway  		string `json:"gateway"`
+	GatewayID      	string `json:"gateway_id,omitempty"`
+	RoutingTableID 	string `json:"routingtable_id"`
+	CIDR     		string `json:"cidr"`
+	ID       		string `json:"id"`
+}
+
+type Subnet struct {
+	RouterExternal 	bool    `json:"router:external"`
+	Name           	string  `json:"name"`
+	EnableDHCP     	bool    `json:"enable_dhcp"`
+	TenantID       	string  `json:"tenant_id"`
+	Gateway        	string  `json:"gateway"`
+	Routes         	[]Route `json:"routes"`
+	State          	string  `json:"state"`
+	CreateTime     	string  `json:"create_time"`
+	AvailableIPCount int   `json:"available_ip_count"`
+	VPC            	VPC     `json:"vpc"`
+	Shared         	bool    `json:"shared"`
+	ID             	string  `json:"id"`
+	VPCID          	string  `json:"vpc_id"`
+	Hidden         	bool    `json:"hidden"`
+	CIDR           	string  `json:"cidr"`
+}
+
+type VPC struct {
+	RouterExternal 	bool     		`json:"router:external"`
+	RoutingTables  	[]RoutingTable 	`json:"routingtables"`
+	Name           	string   		`json:"name"`
+	Subnets        	[]Subnet 		`json:"subnets"`
+	TenantID       	string   		`json:"tenant_id"`
+	State          	string   		`json:"state"`
+	CreateTime     	string   		`json:"create_time"`
+	CIDRv4         	string   		`json:"cidrv4"`
+	Shared         	bool     		`json:"shared"`
+	ID             	string   		`json:"id"`
+}
+
+func (r *VPC) UnmarshalJSON(b []byte) error {
+	type tmp VPC
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = VPC(s1.tmp)
+		return nil
+	}
+
+	return err // Caution!!
+}
+
+// VPCPage is the page returned by a pager when traversing over a
+// collection of networks.
+type VPCPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of networks has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r VPCPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"vpcs_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a VPCPage struct is empty.
+func (r VPCPage) IsEmpty() (bool, error) {
+	is, err := ExtractVPCs(r)
+	return len(is) == 0, err
+}
+
+// ExtractVPCs accepts a Page struct, specifically a VPCPage struct,
+// and extracts the elements into a slice of VPC structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractVPCs(r pagination.Page) ([]VPC, error) {
+	var s []VPC
+	err := ExtractVPCsInto(r, &s)
+	return s, err
+}
+
+func ExtractVPCsInto(r pagination.Page, v interface{}) error {
+	return r.(VPCPage).Result.ExtractIntoSlicePtr(v, "vpcs")
+}

--- a/openstack/networking/v2/vpcs/urls.go
+++ b/openstack/networking/v2/vpcs/urls.go
@@ -1,0 +1,41 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// Created by ETRI, 2024.02
+
+package vpcs
+
+import "github.com/cloud-barista/nhncloud-sdk-go"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("vpcs", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("vpcs")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
- Apply New REST API for NHN Cloud VPC and Subnet
  - Apply Modified Request Structure of VPC and Subnet
  - Apply Modified Response Structure of VPC and Subnet
  - Apply Modified API URL
    - networsks -> vpcs
    - subnets -> vpcsubnets
