### PR TITLE
Support GET /v1/supports API

### DIFF
--- a/openstack/containerinfra/v1/clusters/requests.go
+++ b/openstack/containerinfra/v1/clusters/requests.go
@@ -239,3 +239,10 @@ func GetConfig(client *gophercloud.ServiceClient, id string) (r ConfigResult) {
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
+
+// GetSupports retrieves a list of supported Kubernetes versions.
+func GetSupports(client *gophercloud.ServiceClient) (r SupportsResult) {
+	resp, err := client.Get(supportsURL(client), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/openstack/containerinfra/v1/clusters/results.go
+++ b/openstack/containerinfra/v1/clusters/results.go
@@ -54,6 +54,11 @@ type ConfigResult struct {
 	commonResult
 }
 
+// SupportsResult is the response of a get supports operation.
+type SupportsResult struct {
+	commonResult
+}
+
 func (r CreateResult) Extract() (string, error) {
 	var s struct {
 		UUID string
@@ -92,6 +97,22 @@ func (r ConfigResult) Extract() (string, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Config, err
+}
+
+type Supports struct {
+	SupportedK8s       map[string]bool `json:"supported_k8s"`
+	SupportedEventType EventType       `json:"supported_event_type"`
+}
+
+type EventType struct {
+	ClusterEvents   map[string]string `json:"cluster_events"`
+	NodegroupEvents map[string]string `json:"nodegroup_events"`
+}
+
+func (r SupportsResult) Extract() (*Supports, error) {
+	var s Supports
+	err := r.ExtractInto(&s)
+	return &s, err
 }
 
 type Cluster struct {

--- a/openstack/containerinfra/v1/clusters/urls.go
+++ b/openstack/containerinfra/v1/clusters/urls.go
@@ -49,3 +49,7 @@ func resizeURL(client *gophercloud.ServiceClient, id string) string {
 func configURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("clusters", id, "config")
 }
+
+func supportsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("supports")
+}


### PR DESCRIPTION
본 PR은 NHNCLOUD에서 제공하는 GET /v1/supports를 지원합니다.
참고: https://docs.nhncloud.com/ko/Container/NKS/ko/public-api/#kubernetes
관련: https://github.com/cloud-barista/cb-spider/issues/1349