### PR TITLE
[Update client.go] To Specify the ServiceType even for services not provided in the region

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -355,6 +355,8 @@ func NewIdentityV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOp
 }
 
 func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient, error) {
+	cblogger.Infof("# ServiceClient Type : [%s]", clientType)
+
 	sc := new(gophercloud.ServiceClient)
 	eo.ApplyDefaults(clientType)
 	url, err := client.EndpointLocator(eo)
@@ -366,9 +368,8 @@ func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 	sc.Endpoint = url
 	sc.Type = clientType
 
-	cblogger.Infof("\n# ServiceClient Type and Endpoint : [%s] : [%s]", sc.Type, sc.Endpoint)
-	cblogger.Info("\n\n")
-
+	cblogger.Infof("# Endpoint for the ClientType: [%s]\n", sc.Endpoint)
+	
 	return sc, nil
 }
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -451,7 +450,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 	}
 
 	if !ok {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		respErr := ErrUnexpectedResponseCode{
 			URL:            url,
@@ -587,7 +586,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		// Don't decode JSON when there is no content
 		if resp.StatusCode == http.StatusNoContent {
 			// read till EOF, otherwise the connection will be closed and cannot be reused
-			_, err = io.Copy(ioutil.Discard, resp.Body)
+			_, err = io.Copy(io.Discard, resp.Body)
 			return resp, err
 		}
 		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
@@ -609,7 +608,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 	if !options.KeepResponseBody && options.JSONResponse == nil {
 		defer resp.Body.Close()
 		// read till EOF, otherwise the connection will be closed and cannot be reused
-		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
- Update client.go
  - Update to specify the ServiceType even for services that are not provided in the region and therefore do not appear as endpoints